### PR TITLE
OBT/1.0.6

### DIFF
--- a/Barotrauma/BarotraumaServer/ServerSource/DebugConsole.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/DebugConsole.cs
@@ -2771,8 +2771,8 @@ namespace Barotrauma
 
             commands.Add(new Command("ShowServerPerf", "Immediately log server performance info in ServerMessage", (string[] args) =>
             {
-                GameServer.Log(PerformenceMonitor.PM.ToString(), ServerLog.MessageType.ServerMessage);
-                NewMessage(PerformenceMonitor.PM.ToString(), Color.Green);
+                GameServer.Log(PerformanceMonitor.PM.ToString(), ServerLog.MessageType.ServerMessage);
+                NewMessage(PerformanceMonitor.PM.ToString(), Color.Green);
             }));
 
 #if DEBUG

--- a/Barotrauma/BarotraumaServer/ServerSource/GameMain.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/GameMain.cs
@@ -330,7 +330,7 @@ namespace Barotrauma
             Stopwatch performanceCounterTimer = Stopwatch.StartNew();
             stopwatch = Stopwatch.StartNew();
 
-            PerformenceMonitor PM = new PerformenceMonitor();
+            PerformanceMonitor PM = new PerformanceMonitor();
 
             long prevTicks = stopwatch.ElapsedTicks;
             while (ShouldRun)
@@ -426,7 +426,7 @@ namespace Barotrauma
                 }
             }
 
-            PerformenceMonitor.PM.Dispose();
+            PerformanceMonitor.PM.Dispose();
 
             stopwatch.Stop();
 

--- a/Barotrauma/BarotraumaServer/ServerSource/PerformenceMonitor.cs
+++ b/Barotrauma/BarotraumaServer/ServerSource/PerformenceMonitor.cs
@@ -11,9 +11,9 @@ using System.Threading.Tasks;
 
 namespace Barotrauma
 {
-    public class PerformenceMonitor
+    public class PerformanceMonitor
     {
-        static public PerformenceMonitor PM;
+        static public PerformanceMonitor PM;
 
         private Stopwatch PMStopwatch = new Stopwatch();
 
@@ -111,7 +111,7 @@ namespace Barotrauma
             get; set;
         }
 
-        public PerformenceMonitor() 
+        public PerformanceMonitor() 
         {
             PM = this;
             RealTickRate = 60;
@@ -161,7 +161,7 @@ namespace Barotrauma
         }
         override public string ToString()
         {
-            return $"Server Performence Info \n" +
+            return $"Server Performance Info \n" +
                    $"Item Count: {ItemCount}\n" +
                    $"Character Count: {CharacterCount}\n" +
                    $"Clients Count {ConnectClients}\n " +

--- a/Barotrauma/BarotraumaShared/SharedSource/Screens/GameScreen.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Screens/GameScreen.cs
@@ -114,7 +114,7 @@ namespace Barotrauma
         public override void Update(double deltaTime)
         {
 
-#warning For now CL side performence counter is partly useless bucz multiple changes on such things. Need time to take care of it
+#warning For now CL side performance counter is partly useless bucz multiple changes on such things. Need time to take care of it
 
 #if RUN_PHYSICS_IN_SEPARATE_THREAD
             physicsTime += deltaTime;


### PR DESCRIPTION
Fixed a typo using "e" instead of "a" in word "performance"